### PR TITLE
여행 게시글 상세보기 기능 추가

### DIFF
--- a/trip/templates/trip_detail.html
+++ b/trip/templates/trip_detail.html
@@ -9,24 +9,24 @@
             </div>
         </section>
         <div class="container">
-            <form action="{% url 'edit_post' post.id %}" method="POST">
+            <form action="" method="POST">
                 <div class="form-group">
                     <label for="subject">여행 제목</label>
-                    <input type="text" class="form-control" id="title" name="title" placeholder="{{ post.title }}">
+                    <input type="text" class="form-control" id="title" name="title" placeholder="{{ trip.title }}">
                 </div>
                 <div class="form-group">
                     <label for="content">여행 일정</label>
                     <div class="form-group" id="parah"></div>
                     <div class="flex_container">
                         <textarea class="form-control whitebackground" id="schedule" name="schedule"
-                                  rows="10">{{ post.schedule }}</textarea>
+                                  rows="10"></textarea>
                         <textarea class="form-control whitebackground" id="body" name="body"
-                                  rows="10">{{ post.body }}</textarea>
+                                  rows="10">{{ trip.explanation }}</textarea>
                     </div>
                     <div class="flex_container">
                         <textarea class="form-control whitebackground" id="Host" name="Host"
-                                  rows="4">{{ post.Host }}</textarea>
-                        <a type="button" class="btn btn-secondary" href="{% url '#' %}">예약</a>
+                                  rows="4">{{ trip.author }}</textarea>
+                        <a type="button" class="btn btn-secondary" href="">예약</a>
                         <!-- 예약을 해야는 경우,
 
 {#            예약을 취소하는 경우<a type="button" class="btn btn-secondary" href="{% url '#' %}">#}

--- a/trip/templates/trip_detail.html
+++ b/trip/templates/trip_detail.html
@@ -18,8 +18,11 @@
                     <label for="content">여행 일정</label>
                     <div class="form-group" id="parah"></div>
                     <div class="flex_container">
-                        <textarea class="form-control whitebackground" id="schedule" name="schedule"
-                                  rows="10"></textarea>
+                        <textarea class="form-control whitebackground" id="schedule" name="schedule" rows="10">
+                           {% for schedule in schedules %}
+                               {{ schedule.place }}
+                           {% endfor %}
+                        </textarea>
                         <textarea class="form-control whitebackground" id="body" name="body"
                                   rows="10">{{ trip.explanation }}</textarea>
                     </div>

--- a/trip/templates/trip_list.html
+++ b/trip/templates/trip_list.html
@@ -18,26 +18,28 @@
                 <div class="row">
                     {% for post in post_list %}
                         <div class="col-md-4">
-                            <div class="card mb-4 shadow-sm">
-                                <div class="card-body">
-                                    <div align="right">
-                                        <small class="text-muted">{{ post.author }}</small>
-                                    </div>
-                                    <h3>
-                                        <p class="card-text">{{ post.title|truncatechars:11 }}</p>
-                                    </h3>
-                                    <p class="card-text">{{ post.explanation|truncatechars:18 }}</p>
-                                    <div class="d-flex justify-content-between align-items-center">
-                                        <div class="btn-group">
-                                            {#                                            <a type="submit" class="btn btn-sm btn-outline-secondary"#}
-                                            {#                                               href="{% url 'view_post' id=post.id %}">View</a>#}
-                                            {#                                            <a type="submit" class="btn btn-sm btn-outline-secondary"#}
-                                            {#                                               href="{% url 'edit_post' id=post.id %}">Edit</a>#}
+                            <a href="{% url 'detail-post' post.id %}">
+                                <div class="card mb-4 shadow-sm">
+                                    <div class="card-body">
+                                        <div align="right">
+                                            <small class="text-muted">{{ post.author }}</small>
                                         </div>
-                                        <small class="text-muted">{{ post.date|date:"D d M Y" }}</small>
+                                        <h3>
+                                            <p class="card-text">{{ post.title|truncatechars:11 }}</p>
+                                        </h3>
+                                        <p class="card-text">{{ post.explanation|truncatechars:18 }}</p>
+                                        <div class="d-flex justify-content-between align-items-center">
+                                            <div class="btn-group">
+                                                {#                                            <a type="submit" class="btn btn-sm btn-outline-secondary"#}
+                                                {#                                               href="{% url 'view_post' id=post.id %}">View</a>#}
+                                                {#                                            <a type="submit" class="btn btn-sm btn-outline-secondary"#}
+                                                {#                                               href="{% url 'edit_post' id=post.id %}">Edit</a>#}
+                                            </div>
+                                            <small class="text-muted">{{ post.date|date:"D d M Y" }}</small>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
+                            </a>
                         </div>
                     {% endfor %}
                 </div>

--- a/trip/urls.py
+++ b/trip/urls.py
@@ -5,4 +5,5 @@ from trip import views
 urlpatterns = [
     path('', views.PostListView.as_view(), name='trips'),
     path('create', views.PostCreateView.as_view(), name='create-post'),
+    path('detail<int:trip_id>', views.PostDetailView.as_view(), name='detail-post')
 ]

--- a/trip/views.py
+++ b/trip/views.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import User
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, get_object_or_404
 from django.views import View
 from django.views.generic import ListView
 
@@ -42,3 +42,10 @@ class PostCreateView(View):
             return redirect('log-in')
 
         return redirect('trips')
+
+
+class PostDetailView(View):
+    @staticmethod
+    def get(request, trip_id):
+        trip = get_object_or_404(Trip, pk=trip_id)
+        return render(request, 'trip_detail.html', {'trip': trip})

--- a/trip/views.py
+++ b/trip/views.py
@@ -48,4 +48,5 @@ class PostDetailView(View):
     @staticmethod
     def get(request, trip_id):
         trip = get_object_or_404(Trip, pk=trip_id)
-        return render(request, 'trip_detail.html', {'trip': trip})
+        schedules = Schedule.objects.filter(trip=trip)
+        return render(request, 'trip_detail.html', {'trip': trip, 'schedules': schedules})


### PR DESCRIPTION
# 변경 내역

1. 여행 게시글을 여행 게시글 리스트에서 클릭했을 때 상세한 정보를 볼 수 있는 기능 추가

# 변경 사유

1. 프로젝트 시연시 여행 게시글에 대한 상세한 정보를 제공할 필요성 존재

# 테스트 방법

1. 여행 게시글 리스트에서 여행 게시글을 클릭해 해당 페이지로 이동하는지 확인한다.